### PR TITLE
Ensure the gecko object is explicitly required

### DIFF
--- a/src/manifest-schema.json
+++ b/src/manifest-schema.json
@@ -5,37 +5,39 @@
     "properties": {
         "applications": {
             "type": "object",
-                "properties": {
-                    "gecko": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "description": "id is the extension ID. Mandatory. See https://developer.mozilla.org/Add-ons/Install_Manifests#id",
-                                "pattern": "^{[A-Fa-f0-9]{8}-([A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}}$|^[A-Za-z0-9-._]+\\@[A-Za-z0-9-._]+$",
-                                "type": "string"
-                            },
-                            "strict_min_version": {
-                                "default": "42a1",
-                                "description": "Minimum version of Gecko to support. Defaults to '42a1'. (Requires Gecko 45)",
-                                "type": "string"
-                            },
-                            "strict_max_version": {
-                                "default": "*",
-                                "description": "Maxiumum version of Gecko to support. Defaults to '*'. (Requires Gecko 45)",
-                                "type": "string"
-                            },
-                            "update_url": {
-                                "description": "Link to an add-on update manifest. (Requires Gecko 45)",
-                                "type": "string",
-                                "format": "uri"
-                            }
+            "properties": {
+                "gecko": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "description": "id is the extension ID. Mandatory. See https://developer.mozilla.org/Add-ons/Install_Manifests#id",
+                            "pattern": "^{[A-Fa-f0-9]{8}-([A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}}$|^[A-Za-z0-9-._]+\\@[A-Za-z0-9-._]+$",
+                            "type": "string"
                         },
-                        "required": [
-                            "id"
-                        ]
-                    }
+                        "strict_min_version": {
+                            "default": "42a1",
+                            "description": "Minimum version of Gecko to support. Defaults to '42a1'. (Requires Gecko 45)",
+                            "type": "string"
+                        },
+                        "strict_max_version": {
+                            "default": "*",
+                            "description": "Maxiumum version of Gecko to support. Defaults to '*'. (Requires Gecko 45)",
+                            "type": "string"
+                        },
+                        "update_url": {
+                            "description": "Link to an add-on update manifest. (Requires Gecko 45)",
+                            "type": "string",
+                            "format": "uri"
+                        }
+                    },
+                    "required": [
+                        "id"
+                    ]
                 }
-
+            },
+            "required": [
+                "gecko"
+            ]
         },
         "name": {
             "description": "Name of the extension. This is used to identify the extension in the browser's user interface and on sites  like addons.mozilla.org.",

--- a/tests/test.applications.js
+++ b/tests/test.applications.js
@@ -5,6 +5,15 @@ import cloneDeep from 'lodash.clonedeep';
 
 describe('/applications/gecko/*', () => {
 
+  it('should require a gecko object', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications.gecko = undefined;
+    validate(manifest);
+    assert.equal(validate.errors.length, 1);
+    assert.equal(validate.errors[0].dataPath, '/applications/gecko');
+    assert.equal(validate.errors[0].params.missingProperty, 'gecko');
+  });
+
   it('should be invalid due to invalid update_url', () => {
     var manifest = cloneDeep(validManifest);
     manifest.applications.gecko.update_url = 'whatevs';


### PR DESCRIPTION
Relates to mozilla/addons-linter/issues/432

I fixed the indent too so using https://github.com/mozilla/web-extension-manifest-schema/pull/45/files?w=1 should make the diff a bit easier to handle.