### PR TITLE
Make add-on id optional (fix #87)

### DIFF
--- a/src/manifest-schema.json
+++ b/src/manifest-schema.json
@@ -10,7 +10,7 @@
                     "type": "object",
                     "properties": {
                         "id": {
-                            "description": "id is the extension ID. Mandatory. See https://developer.mozilla.org/Add-ons/Install_Manifests#id",
+                            "description": "id is the extension ID. Optional. See https://developer.mozilla.org/Add-ons/Install_Manifests#id",
                             "pattern": "^{[A-Fa-f0-9]{8}-([A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}}$|^[A-Za-z0-9-._]+\\@[A-Za-z0-9-._]+$",
                             "type": "string"
                         },
@@ -29,10 +29,7 @@
                             "type": "string",
                             "format": "uri"
                         }
-                    },
-                    "required": [
-                        "id"
-                    ]
+                    }
                 }
             },
             "required": [

--- a/tests/test.applications.js
+++ b/tests/test.applications.js
@@ -61,13 +61,11 @@ describe('/applications/gecko/*', () => {
       '/applications/gecko/id');
   });
 
-  it('should be invalid due to missing required id', () => {
+  it('should accept an add-on without an id', () => {
     var manifest = cloneDeep(validManifest);
     manifest.applications.gecko.id = undefined;
     validate(manifest);
-    assert.equal(validate.errors.length, 1);
-    assert.equal(validate.errors[0].dataPath, '/applications/gecko/id');
-    assert.equal(validate.errors[0].params.missingProperty, 'id');
+    assert.isNull(validate.errors);
   });
 
 });


### PR DESCRIPTION
After deployed, update https://github.com/mozilla/addons-linter/issues/568.

@EnTeQuAk, asking for r? from you but if you wanna wait 'til @muffinresearch is back (as he wrote nearly all of this) that's cool.