### PR TITLE
Allow applications(/gecko) to be empty.

### DIFF
--- a/src/manifest-schema.json
+++ b/src/manifest-schema.json
@@ -21,7 +21,7 @@
                         },
                         "strict_max_version": {
                             "default": "*",
-                            "description": "Maxiumum version of Gecko to support. Defaults to '*'. (Requires Gecko 45)",
+                            "description": "Maximum version of Gecko to support. Defaults to '*'. (Requires Gecko 45)",
                             "type": "string"
                         },
                         "update_url": {

--- a/src/manifest-schema.json
+++ b/src/manifest-schema.json
@@ -31,10 +31,7 @@
                         }
                     }
                 }
-            },
-            "required": [
-                "gecko"
-            ]
+            }
         },
         "name": {
             "description": "Name of the extension. This is used to identify the extension in the browser's user interface and on sites  like addons.mozilla.org.",
@@ -53,7 +50,6 @@
         }
     },
     "required": [
-        "applications",
         "name",
         "manifest_version",
         "version"

--- a/tests/test.applications.js
+++ b/tests/test.applications.js
@@ -3,15 +3,22 @@ import { validManifest } from './helpers';
 import cloneDeep from 'lodash.clonedeep';
 
 
+describe('/applications/*', () => {
+  it('should not require an application object', () => {
+    var manifest = cloneDeep(validManifest);
+    manifest.applications = undefined;
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+});
+
 describe('/applications/gecko/*', () => {
 
-  it('should require a gecko object', () => {
+  it('should not require a gecko object', () => {
     var manifest = cloneDeep(validManifest);
     manifest.applications.gecko = undefined;
     validate(manifest);
-    assert.equal(validate.errors.length, 1);
-    assert.equal(validate.errors[0].dataPath, '/applications/gecko');
-    assert.equal(validate.errors[0].params.missingProperty, 'gecko');
+    assert.isNull(validate.errors);
   });
 
   it('should be invalid due to invalid update_url', () => {


### PR DESCRIPTION
This represents what the mozilla-central schema has: https://dxr.mozilla.org/mozilla-central/source/toolkit/components/extensions/schemas/manifest.json#16

it set's `application` and `application.gecko` to optional.