### PR TITLE
Add support for background.persistent and better relative url validation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/mozilla/web-extension-manifest-schema#readme",
   "dependencies": {
-    "ajv": "4.0.6"
+    "ajv": "4.0.6",
+    "url-parse": "1.1.1"
   },
   "devDependencies": {
     "babel-core": "6.9.1",

--- a/src/formats.js
+++ b/src/formats.js
@@ -1,5 +1,6 @@
+import parse from 'url-parse';
+
 const VALIDNUMRX = /^[0-9]{1,5}$/;
-const RELATIVE_URL_REGEX = /^(?!(.+|)\/)/;
 
 
 export function isValidVersionString(version) {
@@ -29,5 +30,11 @@ export function isValidVersionString(version) {
 }
 
 export function isRelativeURL(url) {
-  return Boolean(url.match(RELATIVE_URL_REGEX));
+  let parsed = parse(url);
+
+  if (parsed.protocol !== '' || parsed.href.startsWith('/')) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/manifest-schema.json
+++ b/src/manifest-schema.json
@@ -67,6 +67,9 @@
                 "page": {
                     "type": "string",
                     "format": "relativeURL"
+                },
+                "persistent": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false

--- a/tests/test.background.js
+++ b/tests/test.background.js
@@ -18,6 +18,13 @@ describe('/background', () => {
 
   it('script relative URL should be valid', () => {
     var manifest = cloneDeep(validManifest);
+    manifest.background = {scripts: ['js/jquery.js']};
+    validate(manifest);
+    assert.isNull(validate.errors);
+  });
+
+  it('script relative URL with path should be valid', () => {
+    var manifest = cloneDeep(validManifest);
     manifest.background = {scripts: ['foo.png']};
     validate(manifest);
     assert.isNull(validate.errors);

--- a/tests/test.background.js
+++ b/tests/test.background.js
@@ -40,14 +40,11 @@ describe('/background', () => {
     assert.isNull(validate.errors);
   });
 
-  it('persistent not expected', () => {
+  it('supports persistent', () => {
     var manifest = cloneDeep(validManifest);
     manifest.background = {persistent: true};
     validate(manifest);
-    assert.equal(validate.errors.length, 1);
-    assert.equal(validate.errors[0].dataPath, '/background/persistent');
-    assert.equal(validate.errors[0].message,
-                 'should NOT have additional properties');
+    assert.isNull(validate.errors);
   });
 
 });

--- a/tests/test.formats.js
+++ b/tests/test.formats.js
@@ -55,6 +55,7 @@ describe('formats.isRelativeURL', () => {
 
   it('should be valid', () => {
     assert.isOk(isRelativeURL('something.png'));
+    assert.isOk(isRelativeURL('js/jquery.js'));
   });
 
 });


### PR DESCRIPTION
This is supported according to https://hg.mozilla.org/mozilla-central/file/tip/toolkit/components/extensions/schemas/manifest.json#l88

@andymckay you explicitly disabled it in https://github.com/mozilla/web-extension-manifest-schema/commit/f471a2749bd5244378f8e72d72a5c49aed427fc9#diff-611c4a5891bedddae077a5d2a9dfd35aR57 - was there any reason for that?

r? @andymckay @tofumatt 

This also adds support for paths like "js/jquery.js".