### PR TITLE
allow urls that start with /

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -32,7 +32,7 @@ export function isValidVersionString(version) {
 export function isRelativeURL(url) {
   let parsed = parse(url);
 
-  if (parsed.protocol !== '' || parsed.href.startsWith('/')) {
+  if (parsed.protocol !== '' || parsed.href.startsWith('//')) {
     return false;
   }
 

--- a/tests/test.background.js
+++ b/tests/test.background.js
@@ -16,9 +16,10 @@ describe('/background', () => {
                  'should match format "relativeURL"');
   });
 
+
   it('script relative URL should be valid', () => {
     var manifest = cloneDeep(validManifest);
-    manifest.background = {scripts: ['js/jquery.js']};
+    manifest.background = {scripts: ['js/jquery.js', '/js/jquery.js']};
     validate(manifest);
     assert.isNull(validate.errors);
   });

--- a/tests/test.formats.js
+++ b/tests/test.formats.js
@@ -44,18 +44,24 @@ describe('formats.isRelativeURL', () => {
     'Https://foo.com/bar',
     'moz-extension://wat',
     '//foo',
-    '/foo',
   ];
 
-  for (const notRelativeURL of notRelativeURLs) {
+  for (let notRelativeURL of notRelativeURLs) {
     it(`${notRelativeURL} should be invalid`, () => {
       assert.notOk(isRelativeURL(notRelativeURL));
     });
   }
 
-  it('should be valid', () => {
-    assert.isOk(isRelativeURL('something.png'));
-    assert.isOk(isRelativeURL('js/jquery.js'));
-  });
+  const relativeURLs = [
+    'something.png',
+    'js/jquery.js',
+    '/js/jquery.js',
+  ];
+
+  for (let relativeURL of relativeURLs) {
+    it(`${relativeURL} should be valid`, () => {
+      assert.isOk(isRelativeURL(relativeURL));
+    });
+  }
 
 });


### PR DESCRIPTION
* fixes mozilla/addons-server#2800
* apparently starting with a / is just fine for Firefox

Just to check I was sane I did try with a protocol and got:

```1464702731004	addons.webextension.<unknown>	ERROR	Loading extension 'null': Reading manifest: Error processing background: Error processing background.scripts.0: SyntaxError: String "https://foo.com/background.js" must be a relative URL```

So I know that should fail.